### PR TITLE
Expose the event types supported by mousetrap

### DIFF
--- a/v-mousetrap/README.md
+++ b/v-mousetrap/README.md
@@ -38,3 +38,7 @@ By default event is bound to the `document`, but with the `.element` modifier th
 ```html
 <textarea v-mousetrap.element="{ bind:'esc', handler: el => el.blur() }"></textarea>
 ```
+Binds the `keypress` event by default, but supports handlers for all event types (mousetrap supports `keypress`, `keydown`, and `keyup`) by passing an object instead of a function.
+```html
+<div v-mousetrap="{ bind: 'b', handler: { keydown: keyDownHandler, keyup: keyUpHandler }"></div>
+```

--- a/v-mousetrap/index.js
+++ b/v-mousetrap/index.js
@@ -8,10 +8,20 @@ function bind(el, value, bindElement) {
     value = [value];
   }
   value.forEach(({ bind, handler, disabled }) => {
+    const handlerType = typeof(handler);
     if (!disabled) {
-      mousetrap.bind(bind, function() {
-        handler.apply(this, [el, ...arguments]);
-      });
+      if (handlerType === 'function') {
+        mousetrap.bind(bind, function() {
+          handler.apply(this, [el, ...arguments]);
+        });
+      } else if (handlerType === 'object') {
+        Object.keys(handler).forEach((eventType) => {
+          const eventHandler = handler[eventType];
+          mousetrap.bind(bind, function() {
+            eventHandler.apply(this, [el, ...arguments]);
+          }, eventType);
+        });
+      }
     }
   });
 }


### PR DESCRIPTION
Mousetrap supports passing a third argument, the event type, to the bind function.  This change makes that functionality availability to users of `vue-utilities`.